### PR TITLE
Adicionando github cli no devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 {
 	"name": "Codespace Main",
 	"image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu",
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y gh",
 	"customizations": {
 		"vscode": {
 			"extensions": [


### PR DESCRIPTION
Adicionei comando para instalar o github cli, na inicialização do Codespaces.